### PR TITLE
Adding CanSIPS Hindcast Client

### DIFF
--- a/src/wxdata/__init__.py
+++ b/src/wxdata/__init__.py
@@ -265,7 +265,8 @@ import wxdata.post_processors.cfs_post_processing as cfs_post_processing
 # - Canadian Global Deterministic Prediction System (GDPS)
 # - Canadian Regional Deterministic Prediction System (RDPS)
 # - Canadian High Resolution Deterministic Prediction System (HRDPS)
-# - Canadian Seasonal to Inter-annual Prediction System (CanSIPS)
+# - Canadian Seasonal to Inter-annual Prediction System (CanSIPS) Forecast
+# - Canadian Seasonal to Inter-annual Prediction System (CanSIPS) Hindcast
 import wxdata.post_processors.cmc_post_processing as cmc_post_processing
 
 # Real-Time Mesoscale Analysis (RTMA)

--- a/src/wxdata/__init__.py
+++ b/src/wxdata/__init__.py
@@ -128,11 +128,13 @@ from wxdata.model_data.ecmwf.ecmwf import(
 # - Canadian Global Deterministic Prediction System (GDPS)
 # - Canadian Regional Deterministic Prediction System (RDPS)
 # - Canadian High Resolution Deterministic Prediction System (HRDPS)
-# - Canadian Seasonal to Inter-annual Prediction System (CanSIPS)
+# - Canadian Seasonal to Inter-annual Prediction System (CanSIPS) Forecasts
+# - Canadian Seasonal to Inter-annual Prediction System (CanSIPS) Hindcasts
 from wxdata.model_data.cmc.gdps.gdps import gdps
 from wxdata.model_data.cmc.rdps.rdps import rdps
 from wxdata.model_data.cmc.hrdps.hrdps import hrdps
-from wxdata.model_data.cmc.cansips.cansips import cansips
+from wxdata.model_data.cmc.cansips.forecast.cansips_forecast import cansips_forecast
+from wxdata.model_data.cmc.cansips.hindcast.cansips_hindcast import cansips_hindcast
 
 
 

--- a/src/wxdata/model_data/cmc/cansips/__init__.py
+++ b/src/wxdata/model_data/cmc/cansips/__init__.py
@@ -1,1 +1,0 @@
-from wxdata.model_data.cmc.cansips.cansips import cansips

--- a/src/wxdata/model_data/cmc/cansips/forecast/__init__.py
+++ b/src/wxdata/model_data/cmc/cansips/forecast/__init__.py
@@ -1,0 +1,1 @@
+from wxdata.model_data.cmc.cansips.forecast.cansips_forecast import cansips_forecast

--- a/src/wxdata/model_data/cmc/cansips/forecast/cansips_forecast.py
+++ b/src/wxdata/model_data/cmc/cansips/forecast/cansips_forecast.py
@@ -1,5 +1,5 @@
 """
-This file hosts the functions for the CanSIPS Data Client
+This file hosts the functions for the CanSIPS Forecast Data Client
 
 (C) Eric J. Drewitz 2025-2026
 """
@@ -10,7 +10,7 @@ _warnings.filterwarnings('ignore')
 import wxdata.post_processors.cmc_post_processing as _cmc_post_processing
 
 from wxdata.model_data.cmc.utils.file_scanner import scan_local_machine as _scan_local_machine
-from wxdata.model_data.cmc.cansips.url_scanner import cansips_url_scanner as _cansips_url_scanner
+from wxdata.model_data.cmc.cansips.forecast.url_scanner import cansips_url_scanner as _cansips_url_scanner
 from wxdata.calc.unit_conversion import convert_temperature_units as _convert_temperature_units
 from wxdata.utils.recycle_bin import(
     clear_recycle_bin_windows as _clear_recycle_bin_windows,
@@ -18,7 +18,7 @@ from wxdata.utils.recycle_bin import(
     clear_trash_bin_linux as _clear_trash_bin_linux
 )
 
-def cansips(western_bound=-180,
+def cansips_forecast(western_bound=-180,
             eastern_bound=180,
             northern_bound=90,
             southern_bound=-90,
@@ -28,7 +28,7 @@ def cansips(western_bound=-180,
             period='monthly',
             category=None,
             proxies=None,
-            path=f"CanSIPS/Geopotential Height/500mb/Monthly",
+            path=f"CanSIPS/Forecast/Geopotential Height/500mb/Monthly",
             chunk_size=8192,
             notifications='off',
             clear_data=False,
@@ -104,7 +104,7 @@ def cansips(western_bound=-180,
                                'https':'http://your-proxy-address:port'
                                }
                                
-    11) path (String) - Default="CanSIPS/Geopotential Height/500mb/Monthly". 
+    11) path (String) - Default="CanSIPS/Forecast/Geopotential Height/500mb/Monthly". 
        The parent directory for the GRIB2 files on the local machine.
        
     12) chunk_size (Integer) - Default=8192. The size of the chunks when writing the GRIB/NETCDF data to a file.
@@ -262,7 +262,7 @@ def cansips(western_bound=-180,
     if process_data == True:
         print("Data Processing...")
         
-        ds = _cmc_post_processing.cansips_post_processing(path,
+        ds = _cmc_post_processing.cansips_forecast_post_processing(path,
                                                             variable,
                                                             western_bound,
                                                             eastern_bound,
@@ -273,7 +273,7 @@ def cansips(western_bound=-180,
             ds = _convert_temperature_units(ds, 
                                         convert_to)
          
-        print("CanSIPS Data Processing Complete!")   
+        print("CanSIPS Forecast Data Processing Complete!")   
         return ds
     else:
         pass

--- a/src/wxdata/model_data/cmc/cansips/forecast/url_scanner.py
+++ b/src/wxdata/model_data/cmc/cansips/forecast/url_scanner.py
@@ -1,5 +1,5 @@
 """
-This file hosts the URL Scanner for the CanSIPS
+This file hosts the URL Scanner for the CanSIPS Forecasts
 
 (C) Eric J. Drewitz 2025-2026
 """

--- a/src/wxdata/model_data/cmc/cansips/hindcast/__init__.py
+++ b/src/wxdata/model_data/cmc/cansips/hindcast/__init__.py
@@ -1,0 +1,1 @@
+from wxdata.model_data.cmc.cansips.hindcast.cansips_hindcast import cansips_hindcast

--- a/src/wxdata/model_data/cmc/cansips/hindcast/cansips_hindcast.py
+++ b/src/wxdata/model_data/cmc/cansips/hindcast/cansips_hindcast.py
@@ -1,0 +1,104 @@
+"""
+This file hosts the functions for the CanSIPS Hindcast Data Client
+
+(C) Eric J. Drewitz 2025-2026
+"""
+import os as _os
+import wxdata.client.client as _client
+import warnings as _warnings
+_warnings.filterwarnings('ignore')
+import wxdata.post_processors.cmc_post_processing as _cmc_post_processing
+
+from wxdata.model_data.cmc.cansips.hindcast.file_sorter import sort_files as _sort_files
+from wxdata.model_data.cmc.utils.file_scanner import scan_local_machine as _scan_local_machine
+from wxdata.model_data.cmc.cansips.hindcast.url_scanner import cansips_hindcast_url_scanner as _cansips_hindcast_url_scanner
+from wxdata.calc.unit_conversion import convert_temperature_units as _convert_temperature_units
+from wxdata.utils.recycle_bin import(
+    clear_recycle_bin_windows as _clear_recycle_bin_windows,
+    clear_trash_bin_mac as _clear_trash_bin_mac,
+    clear_trash_bin_linux as _clear_trash_bin_linux
+)
+
+def cansips_hindcast(western_bound=-180,
+                     eastern_bound=180,
+                     northern_bound=90,
+                     southern_bound=-90,
+                     level_type='pressure',
+                     level=500,
+                     variable='geopotential height',
+                     proxies=None,
+                     clear_recycle_bin=False,
+                     convert_temperature=True,
+                     convert_to='celsius',
+                     process_data=True,
+                     path=f"CanSIPS/Hindcast",
+                     chunk_size=8192,
+                     notifications='off',
+                     clear_data=False):
+    
+    """
+    
+    """
+    
+    if clear_recycle_bin == True:
+        _clear_recycle_bin_windows()
+        _clear_trash_bin_mac()
+        _clear_trash_bin_linux()
+    else:
+        pass
+    
+    print(f"Scanning https://dd.weather.gc.ca/ for the latest requested data.")
+    print("Please Wait...")
+    
+    urls, files = _cansips_hindcast_url_scanner(level_type,
+                                 variable,
+                                 level,
+                                 proxies)
+    
+    print(f"Server Scan Complete!")
+
+    download = _scan_local_machine(urls,
+                                    f"{path}/2020")
+    
+    if download == True or clear_data == True:
+        print("Downloading Data")
+        try:
+            for file in _os.listdir(path):
+                _os.remove(f"{path}/{file}")
+        except Exception as e:
+            pass
+        
+        for url, file in zip(urls, files):
+            _client.get_gridded_data(url,
+                                     f"{path}/Temp",
+                                     file,
+                                    proxies=proxies,
+                                    chunk_size=chunk_size,
+                                    notifications=notifications)
+        _sort_files(f"{path}",
+                    urls)
+
+        print("CanSIPS Download Complete!")
+    else:
+        print("CanSIPS Data Is Up To Date\nSkipping Download...")
+        
+    if process_data == True:
+        
+        ds = _cmc_post_processing.cansips_hindcast_post_processing(path,
+                                                                    variable,
+                                                                    western_bound,
+                                                                    eastern_bound,
+                                                                    northern_bound,
+                                                                    southern_bound)
+        
+        if convert_temperature == True:
+            ds = _convert_temperature_units(ds, 
+                                        convert_to)
+         
+        print("CanSIPS Hindcast Data Processing Complete!")   
+        return ds
+    else:
+        pass
+        
+        
+        

--- a/src/wxdata/model_data/cmc/cansips/hindcast/cansips_hindcast.py
+++ b/src/wxdata/model_data/cmc/cansips/hindcast/cansips_hindcast.py
@@ -37,7 +37,119 @@ def cansips_hindcast(western_bound=-180,
                      clear_data=False):
     
     """
+    This function is a client that retrieves the CanSIPS Hindcast Data for the current month and calculates the
+    30-year mean to find anomalies when comparing to the CanSIPS forecast as described here: 
     
+    https://eccc-msc.github.io/open-data/msc-data/nwp_cansips/readme_cansips-datamart_en/
+    
+    Required Arguments: None
+    
+    Optional Arguments:
+    
+    1) western_bound (Float or Integer) - Default=-180. The western bound of the data needed. 
+
+    2) eastern_bound (Float or Integer) - Default=180. The eastern bound of the data needed.
+
+    3) northern_bound (Float or Integer) - Default=90. The northern bound of the data needed.
+
+    4) southern_bound (Float or Integer) - Default=-90. The southern bound of the data needed.
+    
+    5) level_type (String) - The type of level surface for the variable.
+    
+    ***Level Types***
+    
+        'height above ground'
+        'pressure'
+        'surface'
+        'geoid'
+        'mean sea level'
+        
+    6) level (Integer) - The pressure level in hPa or height above ground in meters.
+    
+    7) variable (String) - Variable the user is requesting.
+    
+    ***Variable List***
+    
+        'temperature'
+        'geopotential height'
+        'precipitation rate'
+        'pressure'
+        'sea surface height'
+        'sea surface temperature'
+        'u-wind component'
+        'v-wind component'
+        
+    8) proxies (dict or None) - Default=None. If the user is using proxy server(s), the user must change the following:
+
+       proxies=None ---> proxies={
+                               'http':'http://your-proxy-address:port',
+                               'https':'http://your-proxy-address:port'
+                               }
+                               
+    9) clear_recycle_bin (Boolean) - Default=False. When set to True, the contents in your recycle/trash bin will be deleted 
+        with each run of the program you are calling WxData. This setting is to help preserve memory on the machine.
+        
+    10) convert_temperature (Boolean) - Default=True. When set to True, the temperature related fields will be converted from Kelvin to
+        either Celsius or Fahrenheit. When False, this data remains in Kelvin.
+        
+    11) convert_to (String) - Default='celsius'. When set to 'celsius' temperature related fields convert to Celsius.
+        Set convert_to='fahrenheit' for Fahrenheit. 
+        
+    12) process_data (Boolean) - Default=True. When set to True, WxData will preprocess the model data. If the user wishes to process the 
+       data via their own external method, set process_data=False which means the data will be downloaded but not processed and no values
+       returned to the user.
+       
+    13) path (String) - Default="CanSIPS/Hindcast". 
+       The parent directory for the GRIB2 files on the local machine.
+       
+    14) chunk_size (Integer) - Default=8192. The size of the chunks when writing the GRIB/NETCDF data to a file.
+    
+    15) notifications (String) - Default='off'. Notification when a file is downloaded and saved to {path}
+    
+    16) clear_data (Boolean) - Default=False. When set to False, the scanner safe-guard remains in place (recommended for most users).
+        When set to True, the scanner safe-guard is disabled and directory branch is cleared and new data is downloaded. 
+        
+    ***Variables & Proper level_type & level & category & period***
+    
+    'temperature':
+        valid level type(s): 'pressure', 'height above ground'.
+        valid levels:
+            level_type='pressure' (hPa): 850.                              
+            level_type='height above ground' (m): 2.
+        
+    'geopotential height':
+        valid level type(s): 'pressure'.
+        valid_levels: 500 (hPa)
+    
+    'precipitation rate':    
+        valid level type(s): 'surface'.
+        valid levels: N/A - User does not need to change around anything here as the only level is surface.
+        
+    'pressure':
+        valid level type(s): 'mean sea level'.
+        valid levels: N/A - User does not need to change around anything here as the only level is mean sea level.
+        
+    'sea surface height':        
+        valid level type(s): 'geoid'.
+        valid levels: N/A - User does not need to change around anything here as the only level is geoid.
+        
+    'sea surface temperature':
+        valid level type(s): 'surface'.
+        valid levels: N/A - User does not need to change around anything here as the only level is surface.
+        
+    'u-wind component':
+        valid level type(s): 'pressure'.
+        valid levels: 850, 200 (hPa).
+        
+    'v-wind component':
+        valid level type(s): 'pressure'.
+        valid levels: 850, 200 (hPa).
+        
+    Returns
+    -------
+    
+    An xarray.array of the 30-year mean of the CanSIPS Hindcast data that corresponds to the month of the current
+    CanSIPS Forecast for the purpose of finding anomalies in the forecast data.     
     """
     
     if clear_recycle_bin == True:
@@ -58,13 +170,15 @@ def cansips_hindcast(western_bound=-180,
     print(f"Server Scan Complete!")
 
     download = _scan_local_machine(urls,
-                                    f"{path}/2020")
+                                    f"{path}/2020/{variable.upper()}")
     
     if download == True or clear_data == True:
         print("Downloading Data")
+        
         try:
-            for file in _os.listdir(path):
-                _os.remove(f"{path}/{file}")
+            for year in range(1991, 2021, 1):
+                for file in _os.listdir(f"{path}/{year}/{variable.upper()}"):
+                    _os.remove(f"{path}/{year}/{variable.upper()}/{file}")
         except Exception as e:
             pass
         
@@ -76,7 +190,8 @@ def cansips_hindcast(western_bound=-180,
                                     chunk_size=chunk_size,
                                     notifications=notifications)
         _sort_files(f"{path}",
-                    urls)
+                    urls,
+                    variable)
 
         print("CanSIPS Download Complete!")
     else:

--- a/src/wxdata/model_data/cmc/cansips/hindcast/file_sorter.py
+++ b/src/wxdata/model_data/cmc/cansips/hindcast/file_sorter.py
@@ -10,7 +10,8 @@ import shutil
 from urllib.parse import urlparse
 
 
-def create_directories(path):
+def create_directories(path,
+                       variable):
     
     """
     Creates file directories for each year.
@@ -18,6 +19,8 @@ def create_directories(path):
     Required Arguments:
     
     1) path (String) - The path of the base directory.
+    
+    2) variable (String) - The variable requested by the user. 
     
     Optional Arguments: None
     
@@ -28,12 +31,13 @@ def create_directories(path):
     """
     
     for i in range(1991, 2021, 1):
-        os.makedirs(f"{path}/{i}", 
+        os.makedirs(f"{path}/{i}/{variable.upper()}", 
                     exist_ok=True)
         
 
 def sort_files(path,
-               urls):
+               urls,
+               variable):
     
     """
     Sorts the files into their proper bins from the temporary folder
@@ -44,6 +48,8 @@ def sort_files(path,
     
     2) urls (String List) - List of URLs to extract the filenames.
     
+    3) variable (String) - The variable requested by the user. 
+    
     Optional Arguments: None
     
     Returns
@@ -52,7 +58,8 @@ def sort_files(path,
     Moves the files from the temporary folder into their respective folders.
     """
     
-    create_directories(path)
+    create_directories(path,
+                       variable)
     
     files = []
     for url in urls:
@@ -72,7 +79,7 @@ def sort_files(path,
     for year, bin in zip(years, bins):
         for file in bin:
             try:
-                os.replace(f"{path}/Temp/{file}", f"{path}/{year}/{file}")
+                os.replace(f"{path}/Temp/{file}", f"{path}/{year}/{variable.upper()}/{file}")
             except Exception as e:
                 pass
             

--- a/src/wxdata/model_data/cmc/cansips/hindcast/file_sorter.py
+++ b/src/wxdata/model_data/cmc/cansips/hindcast/file_sorter.py
@@ -1,0 +1,84 @@
+"""
+This file hosts the file sorter for the CanSIPS Hindcast Files.
+
+(C) Eric J. Drewitz 2025-2026
+"""
+
+import os
+import shutil
+
+from urllib.parse import urlparse
+
+
+def create_directories(path):
+    
+    """
+    Creates file directories for each year.
+    
+    Required Arguments:
+    
+    1) path (String) - The path of the base directory.
+    
+    Optional Arguments: None
+    
+    Returns
+    -------
+    
+    A series of directories binned by year.
+    """
+    
+    for i in range(1991, 2021, 1):
+        os.makedirs(f"{path}/{i}", 
+                    exist_ok=True)
+        
+
+def sort_files(path,
+               urls):
+    
+    """
+    Sorts the files into their proper bins from the temporary folder
+    
+    Required Arguments:
+    
+    1) path (String) - The path of the base directory.
+    
+    2) urls (String List) - List of URLs to extract the filenames.
+    
+    Optional Arguments: None
+    
+    Returns
+    -------
+    
+    Moves the files from the temporary folder into their respective folders.
+    """
+    
+    create_directories(path)
+    
+    files = []
+    for url in urls:
+        parsed_url = urlparse(url)
+        basename = os.path.basename(parsed_url.path)
+        files.append(basename)
+        
+    # Extract sorted unique years
+    years = sorted({int(f[:4]) for f in files})
+
+    # Build bins as a list of lists
+    bins = [
+        [f for f in files if int(f[:4]) == year]
+        for year in years
+    ]
+    
+    for year, bin in zip(years, bins):
+        for file in bin:
+            try:
+                os.replace(f"{path}/Temp/{file}", f"{path}/{year}/{file}")
+            except Exception as e:
+                pass
+            
+    try:
+        shutil.rmtree(f"{path}/Temp")
+    except Exception as e:
+        pass
+
+        

--- a/src/wxdata/model_data/cmc/cansips/hindcast/url_scanner.py
+++ b/src/wxdata/model_data/cmc/cansips/hindcast/url_scanner.py
@@ -1,0 +1,297 @@
+"""
+This file hosts the URL Scanner for the CanSIPS Hindcasts
+
+(C) Eric J. Drewitz 2025-2026
+"""
+import requests
+import sys
+import time
+import wxdata.model_data.cmc.utils._exceptions as _exceptions
+
+from wxdata.model_data.cmc.utils.filenames import get_filenames
+from wxdata.model_data.cmc.utils.cmc_keys import cansips_hindcast_keys
+# Exception handling for Python >= 3.13 and Python < 3.13
+try:
+    from datetime import datetime, timedelta, UTC
+except Exception as e:
+    from datetime import datetime, timedelta
+
+# Gets current time in UTC
+try:
+    now = datetime.now(UTC)
+except Exception as e:
+    now = datetime.utcnow()
+
+# Gets local time
+local = datetime.now()
+
+# Gets yesterday's date
+last_month = now - timedelta(days=31)
+
+if now.month < 10:
+    month = f"0{now.month}"
+else:
+    month = f"{now.month}"
+    
+if last_month.month < 10:
+    prev_month = f"0{last_month.month}"
+else:
+    prev_month = f"{last_month.month}"
+
+current_dirs = []
+prev_dirs = []
+for i in range(1991, 2021, 1):
+    current_dir = f"https://dd.weather.gc.ca/{now.strftime('%Y%m%d')}/WXO-DD/model_cansips/100km/hindcast/{i}/{month}/"
+    previous_dir = f"https://dd.weather.gc.ca/{now.strftime('%Y%m%d')}/WXO-DD/model_cansips/100km/hindcast/{i}/{prev_month}/"
+    current_dirs.append(current_dir)
+    prev_dirs.append(previous_dir)
+
+
+def cansips_hindcast_url_scanner(level_type,
+                                 variable,
+                                 level,
+                                 proxies):
+    
+    """
+    This function scans for the latest available CanSIPS hindcast data from https://dd.weather.gc.ca/
+    
+    Required Arguments:
+    
+    1) level_type (String) - The type of level surface for the variable.
+    
+    ***Level Types***
+    
+        'height above ground'
+        'pressure'
+        'surface'
+        'geoid'
+        'mean sea level'
+        
+    2) variable (String) - Variable the user is requesting.
+    
+    ***Variable List***
+    
+        'temperature'
+        'geopotential height'
+        'precipitation rate'
+        'pressure'
+        'sea surface height'
+        'sea surface temperature'
+        'u-wind component'
+        'v-wind component'
+        
+    3) level (Integer) - The pressure level in hPa or height above ground in meters.
+    
+    4) proxies (dict or None) - Default=None. If the user is using proxy server(s), the user must change the following:
+
+       proxies=None ---> proxies={
+                               'http':'http://your-proxy-address:port',
+                               'https':'http://your-proxy-address:port'
+                               }
+                               
+    Optional Arguments: None
+    
+    Returns
+    -------
+    
+    A list of all the download URLs and the filenames of the files being downloaded.     
+    """
+    
+    variable = cansips_hindcast_keys(variable)
+    
+    level_type = level_type.lower()
+    
+    current_files = []
+    prev_files = []
+    if level_type == 'height above ground':
+        for j in range(1991, 2021, 1):
+            current = []
+            prev = []
+            for i in range(0, 12, 1):
+                if i < 10:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}_AGL-{level}m_LatLon1.0_P0{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}_AGL-{level}m_LatLon1.0_P0{i}M.grib2"
+                else:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}_AGL-{level}m_LatLon1.0_P{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}_AGL-{level}m_LatLon1.0_P{i}M.grib2"
+                    
+                current.append(current_file)
+                prev.append(prev_file)
+                
+            current_files.append(current)
+            prev_files.append(prev)
+        
+    elif level_type == 'pressure':
+        
+        if level < 1000:
+            level = f"0{level}"
+        else:
+            level = level
+        
+        for j in range(1991, 2021, 1):
+            current = []
+            prev = []
+            for i in range(0, 12, 1):
+                if i < 10:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}_ISBL-{level}_LatLon1.0_P0{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}_ISBL-{level}_LatLon1.0_P0{i}M.grib2"
+                else:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}_ISBL-{level}_LatLon1.0_P{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}_ISBL-{level}_LatLon1.0_P{i}M.grib2"
+                    
+                current.append(current_file)
+                prev.append(prev_file)
+                
+            current_files.append(current)
+            prev_files.append(prev)
+        
+    elif level_type == 'surface':
+        for j in range(1991, 2021, 1):
+            current = []
+            prev = []
+            for i in range(0, 12, 1):
+                if i < 10:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}_Sfc_LatLon1.0_P0{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}_Sfc_LatLon1.0_P0{i}M.grib2"
+                else:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}_Sfc_LatLon1.0_P{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}_Sfc_LatLon1.0_P{i}M.grib2"   
+                    
+                current.append(current_file)
+                prev.append(prev_file)   
+                
+            current_files.append(current)
+            prev_files.append(prev)          
+        
+    elif level_type == 'mean sea level':
+        for j in range(1991, 2021, 1):
+            current = []
+            prev = []
+            for i in range(0, 12, 1):
+                if i < 10:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}_MSL_LatLon1.0_P0{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}_MSL_LatLon1.0_P0{i}M.grib2"
+                else:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}_MSL_LatLon1.0_P{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}_MSL_LatLon1.0_P{i}M.grib2"    
+                    
+                current.append(current_file)
+                prev.append(prev_file)   
+                
+            current_files.append(current)
+            prev_files.append(prev)              
+        
+    else:
+        for j in range(1991, 2021, 1):
+            current = []
+            prev = []
+            for i in range(0, 12, 1):
+                if i < 10:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}-Geoid_LatLon1.0_P0{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}-Geoid_LatLon1.0_P0{i}M.grib2"
+                else:
+                    current_file = f"{j}{month}_MSC_CanSIPS-Hindcast_{variable}-Geoid_LatLon1.0_P{i}M.grib2"
+                    prev_file = f"{j}{prev_month}_MSC_CanSIPS-Hindcast_{variable}-Geoid_LatLon1.0_P{i}M.grib2"
+                    
+                current.append(current_file)
+                prev.append(prev_file)   
+                
+            current_files.append(current)
+            prev_files.append(prev)        
+
+    if proxies == None:   
+        try:
+            r0 = requests.get(f"{current_dirs[-1]}{current_files[-1][-1]}",
+                            stream=True)
+            r0.close()
+            
+            r1 = requests.get(f"{prev_dirs[-1]}{prev_files[-1][-1]}",
+                            stream=True)
+            r1.close()
+            
+        except Exception as e:
+            for i in range(0, 10, 1):
+                time.sleep(60)
+                try:
+                    r0 = requests.get(f"{current_dirs[-1]}{current_files[-1][-1]}",
+                                    stream=True)
+                    r0.close()
+                    
+                    r1 = requests.get(f"{prev_dirs[-1]}{prev_files[-1][-1]}",
+                                    stream=True)
+                    r1.close() 
+                    
+                except Exception as e:
+                    i = i
+                    if i >= 9:
+                        print("Error: Client cannot establish connection to: https://dd.weather.gc.ca/")   
+                        print("System Exit")
+                        sys.exit(1)     
+                    else:
+                        pass  
+                    
+    else:
+        try:
+            r0 = requests.get(f"{current_dirs[-1]}{current_files[-1][-1]}",
+                            stream=True,
+                            proxies=proxies)
+            r0.close()
+            
+            r1 = requests.get(f"{prev_dirs[-1]}{prev_files[-1][-1]}",
+                            stream=True,
+                            proxies=proxies)
+            r1.close()
+            
+        except Exception as e:
+            for i in range(0, 10, 1):
+                time.sleep(60)
+                try:
+                    r0 = requests.get(f"{current_dirs[-1]}{current_files[-1][-1]}",
+                                    stream=True,
+                                    proxies=proxies)
+                    r0.close()
+                    
+                    r1 = requests.get(f"{prev_dirs[-1]}{prev_files[-1][-1]}",
+                                    stream=True,
+                                    proxies=proxies)
+                    r1.close() 
+                    
+                except Exception as e:
+                    i = i
+                    if i >= 9:
+                        print("Error: Client cannot establish connection to: https://dd.weather.gc.ca/")   
+                        print("System Exit")
+                        sys.exit(1)     
+                    else:
+                        pass  
+                    
+    if r0.status_code == 200:
+        dirs = current_dirs
+        files = current_files
+    elif r0.status_code != 200 and r1.status_code == 200:
+        dirs = prev_dirs
+        files = prev_files
+    else:
+        _exceptions.invalid_cansips_hindcast_request()
+        sys.exit(1)
+        
+    urls = []
+    for d, f in zip(dirs, files):
+        for file in f:
+            url = f"{d}{file}"
+            urls.append(url)
+            
+    files = get_filenames(urls)
+            
+    return urls, files
+            
+        
+        
+        
+                        
+    
+    
+    
+    
+    
+    

--- a/src/wxdata/model_data/cmc/geps/url_scanner.py
+++ b/src/wxdata/model_data/cmc/geps/url_scanner.py
@@ -1,0 +1,29 @@
+"""
+This file hosts the URL Scanner for the GEPS
+
+(C) Eric J. Drewitz 2025-2026
+"""
+import requests
+import sys
+import time
+import wxdata.model_data.cmc.utils._exceptions as _exceptions
+
+from wxdata.model_data.cmc.utils.filenames import get_filenames
+# Exception handling for Python >= 3.13 and Python < 3.13
+try:
+    from datetime import datetime, timedelta, UTC
+except Exception as e:
+    from datetime import datetime, timedelta
+
+# Gets current time in UTC
+try:
+    now = datetime.now(UTC)
+except Exception as e:
+    now = datetime.utcnow()
+
+# Gets local time
+local = datetime.now()
+
+# Gets yesterday's date
+yd = now - timedelta(days=1)
+

--- a/src/wxdata/model_data/cmc/utils/_exceptions.py
+++ b/src/wxdata/model_data/cmc/utils/_exceptions.py
@@ -78,3 +78,23 @@ def invalid_cansips_request():
           
           
           """)
+    
+    
+def invalid_cansips_hindcast_request():
+    
+    """
+    Returns error message for an invalid CanSIPS hindcast request
+    """
+    
+    print(f"""
+          
+          Error: User submitted an invalid request for CanSIPS Hindcast data.
+          
+          Things to know when submitting a request for CanSIPS Hindcast data:
+          
+          1) 850mb (level=850) is the only valid level for air temperature forecasts of level_type='pressure'.
+          2) Any requests related to precipitation, sea surface temperature and/or precipitation rate are of level_type='surface'.
+          3) Any request related to sea surface height is always of level_type='geoid'.
+          4) Any request related to u and v wind components are only valid at either level=850 or level=200 and are always of level_type='pressure'          
+          
+          """)

--- a/src/wxdata/model_data/cmc/utils/cmc_keys.py
+++ b/src/wxdata/model_data/cmc/utils/cmc_keys.py
@@ -417,7 +417,7 @@ def hrdps_variable_keys(variable):
 def cansips_variable_keys(variable):
     
     """
-        This function returns the variable in the filename to make our HTTPS request.
+    This function returns the variable in the filename to make our HTTPS request.
     
     Required Argument:
     
@@ -460,6 +460,100 @@ def cansips_variable_keys(variable):
         return variables[variable]
     except Exception as e:
         _invalid_key(variable)
+        
+        
+def geps_variable_keys(variable):
     
+    """
+    This function returns the variable in the filename to make our HTTPS request.
+    
+    Required Argument:
+    
+    1) variable (String) - The variable the user wants to query.
+    
+    ***Variable List***
+    
+        'freezing rain accumulation'
+        'ice pellets accumulation'
+        'total convective precipitation'
+        'rain accumulation'
+        'snow accumulation'
+        'cape'
+        'cin'
+        'downward longwave radiation flux'
+        'downward shortwave radiation flux'
+        'geopotential height'
+        'sea ice thickness'
+        'latent heat net flux'
+        'outgoing longwave radiation'
+        'pressure'
+        'mean sea level pressure'
+        'precipitable water'
+        'relative humidity'
+        'surface runoff'
+        'sensible heat net flux'
+        'snow depth'
+        'specific humidity'
+        'soil moisture'
+        'total cloud cover'
+        'maximum temperature'
+        'minimum temperature'
+        'temperature'
+        'soil temperature'
+        'u-wind component'
+        'v-wind component'
+        'upward longwave radiation flux'
+        'upward shortwave radiation flux'
+        'vertical velocity'
+        'wind speed'
+        
+    Optional Arguments: None
+    
+    Returns
+    -------
+    
+    The variable in the format on the filename to make our HTTPS request.  
+    """
+    
+    variables = {
+        
+        'freezing rain accumulation':'AFRAIN',
+        'ice pellets accumulation':'AICEP',
+        'total convective precipitation':'APCP',
+        'rain accumulation':'ARAIN',
+        'snow accumulation':'ASNOW',
+        'cape':'CAPE',
+        'cin':'CIN',
+        'downward longwave radiation flux':'HRDPS_DLWRF',
+        'downward shortwave radiation flux':'HRDPS_DSWRF',
+        'geopotential height':'HGT',
+        'sea ice thickness':'ICETK',
+        'latent heat net flux':'LHTFL',
+        'outgoing longwave radiation':'OLR',
+        'pressure':'PRES',
+        'mean sea level pressure':'PRMSL',
+        'precipitable water':'PWAT',
+        'relative humidity':'RH',
+        'surface runoff':'SFCWRO',
+        'sensible heat net flux':'HRDPS_SHTFL',
+        'snow depth':'SNOD',
+        'specific humidity':'SPFH',
+        'soil moisture':'SWAT',
+        'total cloud cover':'TCDC',
+        'maximum temperature':'TMAX',
+        'minimum temperature':'TMIN',
+        'temperature':'TMP',
+        'soil temperature':'TSOIL',
+        'u-wind component':'UGRD',
+        'v-wind component':'VGRD',
+        'upward longwave radiation flux':'ULWRF',
+        'upward shortwave radiation flux':'USWRF',
+        'vertical velocity':'VVEL',
+        'wind speed':'WIND'
+        
+    }
 
-
+    try:
+        return variables[variable]
+    except Exception as e:
+        _invalid_key(variable)

--- a/src/wxdata/model_data/cmc/utils/cmc_keys.py
+++ b/src/wxdata/model_data/cmc/utils/cmc_keys.py
@@ -460,7 +460,53 @@ def cansips_variable_keys(variable):
         return variables[variable]
     except Exception as e:
         _invalid_key(variable)
+      
+def cansips_hindcast_keys(variable):
+    
+    """
+    This function returns the variable in the filename to make our HTTPS request.
+    
+    Required Argument:
+    
+    1) variable (String) - The variable the user wants to query.
+    
+    ***Variable List***
+    
+        'temperature'
+        'geopotential height'
+        'precipitation rate'
+        'pressure'
+        'sea surface height'
+        'sea surface temperature'
+        'u-wind component'
+        'v-wind component'
         
+    Optional Arguments: None
+    
+    Returns
+    -------
+    
+    The variable in the format on the filename to make our HTTPS request.  
+    
+    
+    """
+    
+    variables = {
+        
+        'temperature':'AirTemp',
+        'geopotential height':'GeopotentialHeight',
+        'precipitation rate':'PrecipRate',
+        'pressure':'Pressure',
+        'sea surface height':'SeaSfcHeight',
+        'sea surface temperature':'WaterTemp',
+        'u-wind component':'WindU',
+        'v-wind component':'WindV'
+    }
+    
+    try:
+        return variables[variable]
+    except Exception as e:
+        _invalid_key(variable)  
         
 def geps_variable_keys(variable):
     
@@ -557,3 +603,4 @@ def geps_variable_keys(variable):
         return variables[variable]
     except Exception as e:
         _invalid_key(variable)
+

--- a/src/wxdata/post_processors/cmc_post_processing.py
+++ b/src/wxdata/post_processors/cmc_post_processing.py
@@ -12,6 +12,7 @@ GRIB variable keys will be post-processed into Plain Language variable keys.
 
 (C) Eric J. Drewitz 2025-2026
 """
+import os as _os
 import xarray as _xr
 import sys as _sys
 import logging as _logging
@@ -234,7 +235,7 @@ def hrdps_post_processing(path,
     return ds
 
 
-def cansips_post_processing(path,
+def cansips_forecast_post_processing(path,
                          variable,
                          western_bound,
                          eastern_bound,
@@ -310,4 +311,103 @@ def cansips_post_processing(path,
     
     return ds
 
+def cansips_hindcast_post_processing(path,
+                         variable,
+                         western_bound,
+                         eastern_bound,
+                         northern_bound,
+                         southern_bound):
+    
+    """
+    This function processes the model data from the CanSIPS by doing the following:
+    
+    1) Re-mapping the GRIB variable keys into a plain-language format.
+    
+    2) Creating a 30-year mean of the hindcast data to use as a climatology for anomalies.
+    
+    Required Arguments:
+    
+    1) path (String) - The path to the directory holding the GRIB2 Data for the CanSIPS.
+    
+    2) variable (String) - The name of the variable to rename our dataset with the proper variable key.
+    
+    3) western_bound (Float or Integer) - The western bound of the data needed. 
+
+    4) eastern_bound (Float or Integer) - The eastern bound of the data needed.
+
+    5) northern_bound (Float or Integer) - The northern bound of the data needed.
+
+    6) southern_bound (Float or Integer) - The southern bound of the data needed.
+    
+    Optional Arguments: None
+
+    Returns
+    -------    
+    
+    An xarray.array of a 30-year mean CanSIPS Hindcast.  
+    """
+    western_bound, eastern_bound = _convert_lon(western_bound, 
+                                                eastern_bound) 
+
+    ds_list = []
+    for folder in _os.listdir(path):
+        try:
+            ds = _xr.open_mfdataset(f"{path}/{folder}/*grib2",
+                                    concat_dim='step', 
+                                    combine='nested', 
+                                    coords='minimal', 
+                                    engine='cfgrib', 
+                                    compat='override', 
+                                    decode_timedelta=False,
+                                    backend_kwargs={"indexpath": ""}).sel(longitude=slice(western_bound, eastern_bound, 1), 
+                                                                                                    latitude=slice(southern_bound, northern_bound, 1))
+            
+            ds = _shift_longitude(ds)
+        except Exception as e:
+            pass
+        
+        try:
+            var = str(list(ds.data_vars)[0])
+            if ' ' in variable:
+                variable = variable.replace(' ', '_')
+            else:
+                pass
+            
+            ds[variable] = ds[var]
+            ds = ds.drop_vars(var)
+        except Exception as e:
+            pass
+
+        try:    
+            ds = ds.sortby('step')
+        except Exception as e:
+            _eccodes_error_message() 
+
+        try:
+            ds = ds.drop_duplicates(dim='step', keep='first')
+        except Exception as e:
+            pass
+        
+        try:
+            ds = ds.mean(dim='number')
+        except Exception as e:
+            pass
+        
+        try:
+            ds_list.append(ds)
+        except Exception as e:
+            pass
+
+    try:
+        ds = _xr.concat(ds_list,
+                        dim='time')
+    except Exception as e:
+        pass
+    
+    try:
+        ds = ds.mean(dim='time')
+    except Exception as e:
+        pass
+    
+    return ds
 

--- a/src/wxdata/post_processors/cmc_post_processing.py
+++ b/src/wxdata/post_processors/cmc_post_processing.py
@@ -352,7 +352,7 @@ def cansips_hindcast_post_processing(path,
     ds_list = []
     for folder in _os.listdir(path):
         try:
-            ds = _xr.open_mfdataset(f"{path}/{folder}/*grib2",
+            ds = _xr.open_mfdataset(f"{path}/{folder}/{variable.upper()}/*grib2",
                                     concat_dim='step', 
                                     combine='nested', 
                                     coords='minimal', 


### PR DESCRIPTION
Adding a client that downloads and processes the CanSIPS Hindcast data that corresponds to the month of the latest CanSIPS Forecast data for the purpose of finding anomalies in the forecast data. The CanSIPS Hindcast data client also calculates the 30-year mean (1991-2020) and returns an `xarray.array` of this 30-year mean for the variable requested by the user. The methodology for finding the anomalies is from: https://eccc-msc.github.io/open-data/msc-data/nwp_cansips/readme_cansips-datamart_en/